### PR TITLE
fix(ci): fix three build failures

### DIFF
--- a/pkgs/caddy/default.nix
+++ b/pkgs/caddy/default.nix
@@ -22,7 +22,7 @@
     else if stdenv.hostPlatform.system == "aarch64-darwin"
     then {
       name = "darwin_arm64";
-      hash = "sha256-/MjMeJFXPq6zv2aCeMcYFY62oZ9y6HpcY5uzdoW1FUY=";
+      hash = "sha256-8adRmNFLE6wAs8Ha18k+xmqgn8gnOlFZO3nZL8cdVE4=";
     }
     else throw "Unsupported platform: ${stdenv.hostPlatform.system}";
 in

--- a/pkgs/code-server/default.nix
+++ b/pkgs/code-server/default.nix
@@ -14,7 +14,7 @@
   yarn,
   python3,
   esbuild,
-  nodejs,
+  nodejs_22,
   node-gyp,
   libsecret,
   xorg,
@@ -27,6 +27,7 @@
 
 let
   system = stdenv.hostPlatform.system;
+  nodejs = nodejs_22;
 
   python = python3;
   yarn' = yarn.override { inherit nodejs; };

--- a/pkgs/pmbootstrap/default.nix
+++ b/pkgs/pmbootstrap/default.nix
@@ -24,8 +24,7 @@ python3Packages.buildPythonApplication rec {
 
   pmb_test = "${src}/test";
 
-  # Tests depend on sudo
-  doCheck = stdenv.hostPlatform.isLinux;
+  doCheck = false;
 
   build-system = [
     python3Packages.setuptools


### PR DESCRIPTION
## Summary

- **caddy**: Update `aarch64-darwin` binary hash — upstream released an updated binary for v2.11.2 (`sha256-8adRmNFLE6wAs8Ha18k+xmqgn8gnOlFZO3nZL8cdVE4=`)
- **code-server**: Pin to `nodejs_22` — v4.105.1 requires Node 22 (`engines.node = "22"`) but the default nixpkgs nodejs is now 24, causing the yarn cache build to fail with "incompatible module"
- **pmbootstrap**: Set `doCheck = false` — all remaining tests require external programs unavailable in the Nix sandbox; every non-disabled test fails with "Can't find all programs required to run", and the test suite was already documented as mostly disabled as impure

## Failures fixed

From run [26273256783](https://github.com/Gao-OS/nixpkgs/actions/runs/26273256783):
- `Build code-server-latest` — `error code-server@0.0.0: The engine "node" is incompatible with this module. Expected version "22". Got "24.14.0"`
- `Build caddy-with-plugins (x86_64-darwin)` — hash mismatch for `caddy_darwin_arm64`
- `Build pmbootstrap-new (x86_64-linux)` — `NonBugError: Can't find all programs required to run` (33 test errors)